### PR TITLE
add design system colors

### DIFF
--- a/src/components/footer/Footer.js
+++ b/src/components/footer/Footer.js
@@ -4,15 +4,15 @@ const Footer = () => {
   return (
     <div className="flow-root items-center bg-white px-16 py-1">
       <div className="float-left flex items-center h-20 space-x-10">
-        <div className="text-2xl pb-2 paytone text-dark">gruepr</div>
-        <div className="text-base font-bold dmsans text-dark text-decoration-line: underline space-x-4">
+        <div className="text-2xl pb-2 paytone text-neutral-500">gruepr</div>
+        <div className="text-base font-bold dmsans text-neutral-500 text-decoration-line: underline space-x-4">
           <Link to="/Faqs">How it works</Link>
           <Link to="/Faqs">FAQs</Link>
           <Link to="/Faqs">Privacy Policy</Link>
         </div>
       </div>
       <div className="float-right flex items-center justify-center h-20 space-x-8">
-        <div className="text-base font-normal dmsans text-dark">
+        <div className="text-base font-normal dmsans text-neutral-500">
           <a onClick={() => console.log("Home")}>info@gruepr.com</a>
         </div>
       </div>

--- a/src/components/header/Header.js
+++ b/src/components/header/Header.js
@@ -6,18 +6,17 @@ const Header = () => {
   return (
     <div className="flow-root items-center bg-white px-16 py-1">
       <div className="float-left flex items-center h-20 space-x-10">
-        <div className="text-2xl pb-2 paytone text-gblue">gruepr</div>
-        <div className="text-base font-bold dmsans text-dark space-x-4">
+        <div className="text-2xl pb-2 paytone text-primary-500">gruepr</div>
+        <div className="text-base font-bold dmsans text-neutral-500 space-x-4">
           <Link to="/">Home</Link>
           <Link to="/Faqs">FAQs</Link>
-
         </div>
       </div>
       <div className="float-right flex items-center justify-center h-20 space-x-8">
-        <div className="text-base font-normal dmsans text-dark">
+        <div className="text-base font-normal dmsans text-neutral-500">
           <a onClick={() => console.log("Home")}>info@gruepr.com</a>
         </div>
-        <button className="bg-dark py-4 px-8 text-base font-bold dmsans text-white">
+        <button className="bg-neutral-500 py-4 px-8 text-base font-bold dmsans text-white">
           <a onClick={() => console.log("FAQs")}>Download</a>
         </button>
       </div>

--- a/src/components/header/Header.js
+++ b/src/components/header/Header.js
@@ -1,6 +1,4 @@
-import { Route, Routes } from "react-router";
 import { Link } from "react-router-dom";
-import FAQs from "../faq-page/Faqs";
 
 const Header = () => {
   return (

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -4,34 +4,56 @@ module.exports = {
   theme: {
     extend: {
       colors: {
-        gblue: "#13A9B2",
-        dark: "#053437",
-        gyellow: "#053437",
-        yellow50: "FFFBF1"
+        transparent: "transparent",
+        current: "currentColor",
+
+        white: "#ffffff",
+
+        primary: {
+          500: "#13A9B2",
+          400: "#42BAC1",
+          300: "#71CBD1",
+          200: "#A1DDE0",
+          100: "#B8E5E8",
+          50: "#E7F6F7",
+        },
+
+        neutral: {
+          500: "#053437",
+          400: "#375D5F",
+          300: "#5E7A7B",
+          200: "#9BAEAF",
+          100: "#B4C2C3",
+          50: "#E6EBEB",
+        },
+
+        accent: {
+          500: "#FFD771",
+          400: "#FFDF8D",
+          300: "#FFE7AA",
+          200: "#FFEFC6",
+          100: "#FFF3D4",
+          50: "#FFFBF1",
+        },
       },
 
       screens: {
-        'mobile': '320px',
-  
-        'tablet': '768px',
-  
-        'laptop': '1024px',
-  
-        'desktop': '1440px',
-  
-        'desktopMax': '1920px',
+        mobile: "320px",
+
+        tablet: "768px",
+
+        laptop: "1024px",
+
+        desktop: "1440px",
+
+        desktopMax: "1920px",
       },
 
       backgroundImage: {
-        'home-hero-bg': "url('../src/img/hero-bg.svg')",
-        'faq-bg' : "url('../src/img/faq-bg.svg')"
-      }
-
-
-    
+        "home-hero-bg": "url('../src/img/hero-bg.svg')",
+        "faq-bg": "url('../src/img/faq-bg.svg')",
+      },
     },
   },
   plugins: [],
 };
-
-


### PR DESCRIPTION
Some of the colors reverted back to black. I've fixed the header and footer but didn't want to touch the other sections. 
Colors taken directly from the [Figma file](https://www.figma.com/file/wL60bSPJ8fTYECm3mWOAbN/Gruepr-Design-System?node-id=0%3A1&t=9HhW6EvwpnH2Gt5t-0).

<img width="1440" alt="Screen Shot 2022-11-14 at 2 14 19 PM" src="https://user-images.githubusercontent.com/91106279/201745940-8fe5dec4-4eea-42ee-834e-deb4a76b2c92.png">

<img width="489" alt="Screen Shot 2022-11-14 at 2 14 43 PM" src="https://user-images.githubusercontent.com/91106279/201745997-f0710702-aed6-46a4-bdea-2d6ba8ceb393.png">
