### PR TITLE
fixing YT embed alignment

### DIFF
--- a/src/components/faq-page/YouTube.js
+++ b/src/components/faq-page/YouTube.js
@@ -48,7 +48,6 @@ export const YouTube = () => {
         </div>
       </div>
       <div className="flex flex-row">
-        <div>
           <div className="px-20">
             <h1 class="py-5 body font-bold">
               {content.faq.howGrueprWorks.surveyMakerAttributes}
@@ -77,7 +76,6 @@ export const YouTube = () => {
               allowfullscreen
             ></iframe>
           </div>
-        </div>
       </div>
     </div>
   );


### PR DESCRIPTION
just removed the extra div tag to fix the alignment on the second row in the YT embeds! will most likely need to pull this change before the FAQs responsiveness ticket, or can just make the same change in that ticket and document it

<img width="1275" alt="Screen Shot 2022-12-01 at 3 19 42 PM" src="https://user-images.githubusercontent.com/55628918/205151512-db2d7245-7639-4215-9aa8-26f38911330c.png">
