### PR TITLE
Create mobile navbar

### DIFF
--- a/src/App.css
+++ b/src/App.css
@@ -41,7 +41,6 @@
 }
 
 @layer components {
-  /* add button styling here */
   .primary-button {
     @apply bg-neutral-500 py-4 px-8 button-text font-bold dmsans text-white;
   }

--- a/src/components/header/HamburgerMenu.js
+++ b/src/components/header/HamburgerMenu.js
@@ -1,0 +1,73 @@
+import { Menu } from "@headlessui/react";
+import hamburger from "../../img/hamburger.svg";
+import { NavLink } from "react-router-dom";
+import content from "../../content/content";
+
+const HamburgerMenu = () => {
+  return (
+    <Menu as="div" className="w-full">
+      <div>
+        <Menu.Button className="inline-block">
+          <img src={hamburger} alt="hamburger menu" />
+        </Menu.Button>
+      </div>
+
+      <Menu.Items
+        className="w-full absolute left-0 top-[81px] bg-white px-[16px] divide-y divide-neutral-50 
+      border border-neutral-200 border-t-0 border-l-0 border-r-0 border-b-1"
+      >
+        <div className="block first-line:space-y-[4px] link no-underline">
+          <Menu.Item>
+            <div className="h-[40px] mt-[12px] py-[8px]">
+              <NavLink
+                to="/"
+                className={({ isActive }) =>
+                  isActive
+                    ? "py-[8px] border-primary-500 border-0 border-b-4"
+                    : ""
+                }
+              >
+                {content.navbar.home}
+              </NavLink>
+            </div>
+          </Menu.Item>
+
+          <Menu.Item>
+            <div className="h-[40px] mt-[12px] py-[8px]">
+              <NavLink
+                to="/Faqs"
+                className={({ isActive }) =>
+                  isActive
+                    ? "py-[8px] border-primary-500 border-0 border-b-4"
+                    : ""
+                }
+              >
+                {content.navbar.faq}
+              </NavLink>
+            </div>
+          </Menu.Item>
+
+          <Menu.Item>
+            <div className="h-[40px] mt-[12px] mb-[8px] py-[8px]">
+              <NavLink
+                to="/AboutUs"
+                className={({ isActive }) =>
+                  isActive
+                    ? "py-[8px] border-primary-500 border-0 border-b-4"
+                    : ""
+                }
+              >
+                {content.navbar.about}
+              </NavLink>
+            </div>
+          </Menu.Item>
+        </div>
+
+        <div className="body font-normal pt-[8px] pb-[16px]">
+          {content.emailText}
+        </div>
+      </Menu.Items>
+    </Menu>
+  );
+};
+export default HamburgerMenu;

--- a/src/components/header/Header.js
+++ b/src/components/header/Header.js
@@ -1,22 +1,48 @@
-import { Link } from "react-router-dom";
+import { NavLink } from "react-router-dom";
 import content from "../../content/content";
+import hamburger from "../../img/hamburger.svg";
 
 const Header = () => {
   return (
-    <div className="flow-root items-center bg-white px-16 py-1">
-      <div className="float-left flex items-center h-20 space-x-10">
-        <div className="text-2xl pb-2 paytone text-primary-500">gruepr</div>
-        <div className="link no-underline space-x-4 laptop:visible mobile:invisible">
-          <Link to="/"> {content.navbar.home} </Link>
+    <div className="bg-white flow-root laptop:px-16 mobile:px-[16px] border border-neutral-200 border-t-0 border-l-0 border-r-0 border-b-1">
+      <div className="h-20 float-left flex items-center laptop:space-x-0 mobile:space-x-[24px]">
+        {/* Hamburger menu in mobile view */}
+        <button className="mobile:flex laptop:hidden">
+          <img src={hamburger} alt="hamburger menu" />
+          {/* <Link to="/"> {content.navbar.home} </Link>
           <Link to="/Faqs"> {content.navbar.faq} </Link>
-          <Link to="/AboutUs"> {content.navbar.about} </Link>
+          <Link to="/AboutUs"> {content.navbar.about} </Link> */}
+        </button>
+
+        <NavLink
+          to="/"
+          className="text-2xl pb-2 paytone text-primary-500 laptop:pr-10"
+        >
+          gruepr
+        </NavLink>
+
+        {/* Visible links in larger navbar */}
+        <div className="link no-underline laptop:space-x-4 tablet:flex mobile:hidden">
+          <NavLink
+            activeStyle=""
+            to="/Faqs"
+            className={({ isActive }) =>
+              isActive
+                ? "border border-primary-500 border-t-0 border-l-0 border-r-0 border-b-4"
+                : ""
+            }
+          >
+            {content.navbar.faq}
+          </NavLink>
+          <NavLink to="/AboutUs"> {content.navbar.about} </NavLink>
         </div>
       </div>
-      <div className="float-right flex items-center justify-center h-20 space-x-8">
-        <div className="body font-normal laptop:visible mobile:invisible">
+
+      <div className="h-20 float-right flex items-center laptop:space-x-8">
+        <div className="body font-normal hidden tablet:flex">
           {content.emailText}
         </div>
-        <button className="laptop:primary-button mobile:p-[16px]">
+        <button className="laptop:primary-button mobile:primary-button mobile:p-[16px]">
           <a onClick={() => console.log("FAQs")}>
             {content.navbar.downloadButton}
           </a>

--- a/src/components/header/Header.js
+++ b/src/components/header/Header.js
@@ -24,17 +24,25 @@ const Header = () => {
         {/* Visible links in larger navbar */}
         <div className="link no-underline laptop:space-x-4 tablet:flex mobile:hidden">
           <NavLink
-            activeStyle=""
             to="/Faqs"
             className={({ isActive }) =>
               isActive
-                ? "border border-primary-500 border-t-0 border-l-0 border-r-0 border-b-4"
-                : ""
+                ? "mt-[12px] mb-[8px] py-[8px] border-primary-500 border-0 border-b-4"
+                : "mt-[12px] mb-[8px] py-[8px]"
             }
           >
             {content.navbar.faq}
           </NavLink>
-          <NavLink to="/AboutUs"> {content.navbar.about} </NavLink>
+          <NavLink
+            to="/AboutUs"
+            className={({ isActive }) =>
+              isActive
+                ? "mt-[12px] mb-[8px] py-[8px] border-primary-500 border-0 border-b-4"
+                : "mt-[12px] mb-[8px] py-[8px]"
+            }
+          >
+            {content.navbar.about}
+          </NavLink>
         </div>
       </div>
 

--- a/src/components/header/Header.js
+++ b/src/components/header/Header.js
@@ -7,7 +7,7 @@ const Header = () => {
     <div className="bg-white flow-root laptop:px-16 mobile:px-[16px] border border-neutral-200 border-t-0 border-l-0 border-r-0 border-b-1">
       <div className="h-20 float-left flex items-center laptop:space-x-0 mobile:space-x-[24px]">
         {/* Hamburger menu in mobile view */}
-        <div className="z-50 tablet:hidden mobile:block">
+        <div className="z-50 laptop:hidden mobile:block">
           <HamburgerMenu />
         </div>
 
@@ -19,7 +19,7 @@ const Header = () => {
         </NavLink>
 
         {/* Visible links in larger navbar */}
-        <div className="link no-underline tablet:space-x-4 tablet:flex mobile:hidden">
+        <div className="link no-underline laptop:space-x-4 laptop:flex mobile:hidden">
           <NavLink
             to="/Faqs"
             className={({ isActive }) =>

--- a/src/components/header/Header.js
+++ b/src/components/header/Header.js
@@ -19,7 +19,7 @@ const Header = () => {
         </NavLink>
 
         {/* Visible links in larger navbar */}
-        <div className="link no-underline laptop:space-x-4 tablet:flex mobile:hidden">
+        <div className="link no-underline tablet:space-x-4 tablet:flex mobile:hidden">
           <NavLink
             to="/Faqs"
             className={({ isActive }) =>
@@ -43,7 +43,7 @@ const Header = () => {
         </div>
       </div>
 
-      <div className="h-20 float-right flex items-center laptop:space-x-8">
+      <div className="h-20 float-right flex items-center tablet:space-x-8">
         <div className="body font-normal hidden tablet:flex">
           {content.emailText}
         </div>

--- a/src/components/header/Header.js
+++ b/src/components/header/Header.js
@@ -1,18 +1,15 @@
 import { NavLink } from "react-router-dom";
 import content from "../../content/content";
-import hamburger from "../../img/hamburger.svg";
+import HamburgerMenu from "./HamburgerMenu";
 
 const Header = () => {
   return (
     <div className="bg-white flow-root laptop:px-16 mobile:px-[16px] border border-neutral-200 border-t-0 border-l-0 border-r-0 border-b-1">
       <div className="h-20 float-left flex items-center laptop:space-x-0 mobile:space-x-[24px]">
         {/* Hamburger menu in mobile view */}
-        <button className="mobile:flex laptop:hidden">
-          <img src={hamburger} alt="hamburger menu" />
-          {/* <Link to="/"> {content.navbar.home} </Link>
-          <Link to="/Faqs"> {content.navbar.faq} </Link>
-          <Link to="/AboutUs"> {content.navbar.about} </Link> */}
-        </button>
+        <div className="z-50 tablet:hidden mobile:block">
+          <HamburgerMenu />
+        </div>
 
         <NavLink
           to="/"

--- a/src/components/header/Header.js
+++ b/src/components/header/Header.js
@@ -4,10 +4,10 @@ import HamburgerMenu from "./HamburgerMenu";
 
 const Header = () => {
   return (
-    <div className="bg-white flow-root laptop:px-16 mobile:px-[16px] border border-neutral-200 border-t-0 border-l-0 border-r-0 border-b-1">
+    <div className="z-50 bg-white flow-root laptop:px-16 mobile:px-[16px] border border-neutral-200 border-t-0 border-l-0 border-r-0 border-b-1">
       <div className="h-20 float-left flex items-center laptop:space-x-0 mobile:space-x-[24px]">
         {/* Hamburger menu in mobile view */}
-        <div className="z-50 laptop:hidden mobile:block">
+        <div className="laptop:hidden mobile:block">
           <HamburgerMenu />
         </div>
 

--- a/src/components/header/Header.js
+++ b/src/components/header/Header.js
@@ -6,19 +6,17 @@ const Header = () => {
     <div className="flow-root items-center bg-white px-16 py-1">
       <div className="float-left flex items-center h-20 space-x-10">
         <div className="text-2xl pb-2 paytone text-primary-500">gruepr</div>
-        <div className="link no-underline space-x-4">
+        <div className="link no-underline space-x-4 laptop:visible mobile:invisible">
           <Link to="/"> {content.navbar.home} </Link>
           <Link to="/Faqs"> {content.navbar.faq} </Link>
           <Link to="/AboutUs"> {content.navbar.about} </Link>
         </div>
       </div>
       <div className="float-right flex items-center justify-center h-20 space-x-8">
-        <div className="body font-normal">
-          {/* <a href="mailto:info@gruepr.com"> */}
+        <div className="body font-normal laptop:visible mobile:invisible">
           {content.emailText}
-          {/* </a> */}
         </div>
-        <button className="primary-button">
+        <button className="laptop:primary-button mobile:p-[16px]">
           <a onClick={() => console.log("FAQs")}>
             {content.navbar.downloadButton}
           </a>

--- a/src/img/hamburger.svg
+++ b/src/img/hamburger.svg
@@ -1,0 +1,8 @@
+<svg width="40" height="40" viewBox="0 0 40 40" fill="none" xmlns="http://www.w3.org/2000/svg">
+<mask id="mask0_360_3906" style="mask-type:alpha" maskUnits="userSpaceOnUse" x="0" y="0" width="40" height="40">
+<rect width="40" height="40" fill="#D9D9D9"/>
+</mask>
+<g mask="url(#mask0_360_3906)">
+<path d="M5 30V27.208H35V30H5ZM5 21.375V18.625H35V21.375H5ZM5 12.792V10H35V12.792H5Z" fill="#1C1B1F"/>
+</g>
+</svg>


### PR DESCRIPTION
Adds a hamburger menu which opens to a dropdown with home, faq, and about pages. (The hero styling is fixed in another pull request. After taking these screenshots I made the navbar have greater z-index to put it on top.)

laptop:
![Screen Shot 2022-12-09 at 01 18 37](https://user-images.githubusercontent.com/91106279/206637706-5e04bcbe-e510-46f6-ba4a-6f6bf4bd0f07.png)

tablet:
![Screen Shot 2022-12-09 at 01 18 43](https://user-images.githubusercontent.com/91106279/206637719-4460087d-bab9-4585-81ee-7ef5d6501d43.png)
![Screen Shot 2022-12-09 at 01 20 11](https://user-images.githubusercontent.com/91106279/206637910-12fe20c6-877d-474a-877f-1321cdf86554.png)

mobile:
![Screen Shot 2022-12-09 at 01 18 49](https://user-images.githubusercontent.com/91106279/206637736-f5db30fd-a4f4-4dd3-8979-209b02d4ad40.png)
![Screen Shot 2022-12-09 at 01 20 06](https://user-images.githubusercontent.com/91106279/206637939-d31ada12-b6e7-474d-b284-ae9e43105c1f.png)
